### PR TITLE
feat(cli): Can skip test files with: `--skip-test` #11

### DIFF
--- a/packages/react-creates/README.md
+++ b/packages/react-creates/README.md
@@ -76,6 +76,7 @@ Here how to do create one in seconds:
 | `-f --function`             | `false`                                         | Force `function` component                                       |
 | `-c --class`                | `false`                                         | Force `class` component                                          |
 | `-s --style <styling>`      | `css`                                           | Selected style                                                   |
+| `--skip-test`               | `false`                                         | Will not create test file                                        |
 
 ### Examples
 

--- a/packages/react-creates/__tests__/tests/copy-template.test.ts
+++ b/packages/react-creates/__tests__/tests/copy-template.test.ts
@@ -1,0 +1,44 @@
+import { tempProjectTestkit } from '../testkit/create-react-app.testkit';
+import { Component } from '../testkit/component.testkit';
+
+describe('Copy Template', () => {
+  let cmpDriver: Component;
+  const driver = tempProjectTestkit();
+
+  driver.beforeAndAfter();
+
+  afterEach(async () => {
+    cmpDriver && (await cmpDriver.delete());
+  });
+
+  it('should create test file', async () => {
+    cmpDriver = await driver.createComponent(
+      'ComponentWithTest'
+    );
+
+    const files = await cmpDriver.getFiles();
+
+    expect(files).toContain(
+      `${cmpDriver.name}.test.js`
+    );
+  });
+
+  it('should not create test file', async () => {
+    cmpDriver = await driver.createComponent(
+      'ComponentWithTest',
+      ['--skip-test']
+    );
+
+    const files = await cmpDriver.getFiles();
+
+    expect(await cmpDriver.isStyleMatch()).toBe(
+      true
+    );
+    expect(files).toContain(
+      `${cmpDriver.name}.js`
+    );
+    expect(files).not.toContain(
+      `${cmpDriver.name}.test.js`
+    );
+  });
+});

--- a/packages/react-creates/src/scripts/component/index.ts
+++ b/packages/react-creates/src/scripts/component/index.ts
@@ -32,9 +32,10 @@ export const createComponent = () =>
     .option("-l --language <scripting>", LANGUAGE_MESSAGE)
     .option("-d --directory <target>", "Component directory", process.cwd())
     .option("-t --type <component>", TYPE_MESSAGE, Types.FUNCTION)
-    .option("-pt --prop-types", "Should add Prop-types")
+    .option("-pt --prop-types", "Should add Prop-types if inside javascript project")
     .option("-f --function", "Generate function component")
     .option("-c --class", "Generate class component")
+    .option("--skip-test", "Will not create test file")
     .option("-s --style <styling>", "Selected the style", Styles.CSS)
     .action(async (name, _) => {
       let {
@@ -46,6 +47,7 @@ export const createComponent = () =>
         css,
         sass,
         propTypes,
+        skipTest,
         function: func,
         directory: target,
         class: klass
@@ -87,6 +89,7 @@ export const createComponent = () =>
           style: await parseStyle(style),
           propTypes: await parsePropTypes({ propTypes, target }),
           entry: Boolean(entry),
+          skipTest: Boolean(skipTest)
         };
 
         optionsLogger(options);

--- a/packages/react-creates/src/scripts/component/run.ts
+++ b/packages/react-creates/src/scripts/component/run.ts
@@ -17,6 +17,6 @@ export const runCreateComponent = async (options: CreateComponentOptions) => {
     type
   );
 
-  await copyTemplate(templatesPath, target);
+  await copyTemplate(templatesPath, target, options);
   await replaceVariables(target, (options as unknown) as Variables);
 };

--- a/packages/react-creates/src/scripts/component/types.ts
+++ b/packages/react-creates/src/scripts/component/types.ts
@@ -10,4 +10,5 @@ export interface CreateComponentOptions {
   style: Styles;
   entry: boolean;
   propTypes: boolean;
+  skipTest: boolean
 }

--- a/packages/react-creates/src/utils/copy-template.ts
+++ b/packages/react-creates/src/utils/copy-template.ts
@@ -1,26 +1,47 @@
-import { exists as existsCb, mkdir as mkdirCb } from "fs";
-import npc from "ncp";
-import { sep } from "path";
-import { promisify } from "util";
+import fs from 'fs';
+import npc, { Options } from 'ncp';
+import { sep } from 'path';
+import { promisify } from 'util';
+import { CreateComponentOptions } from '../scripts/component/types';
 
 const copy = promisify(npc);
-const exists = promisify(existsCb);
-const mkdir = promisify(mkdirCb);
+const exists = promisify(fs.exists);
+const mkdir = promisify(fs.mkdir);
 
-const isTemp = process.env.TEMP === "true";
-const shouldAddTemp = (path) => path + (isTemp ? sep + "__temp" : "");
+const isDir = (file: string) =>
+  fs.lstatSync(file).isDirectory();
+const isTemp = process.env.TEMP === 'true';
+const shouldAddTemp = (path) =>
+  path + (isTemp ? sep + '__temp' : '');
 
 export const copyTemplate = async (
   templatesPath: string,
-  targetComponentPath: string
+  targetComponentPath: string,
+  options: CreateComponentOptions
 ) => {
-  const targetComponentPathExists = await exists(targetComponentPath);
+  const targetComponentPathExists = await exists(
+    targetComponentPath
+  );
 
   if (!targetComponentPathExists) {
     await mkdir(targetComponentPath);
   }
 
-  await copy(templatesPath, shouldAddTemp(targetComponentPath), {
+  const copyOptions: Options = {
     clobber: true,
-  });
+  };
+
+  if (options.skipTest) {
+    copyOptions.filter = (file) =>
+      isDir(file) ||
+      /^(?!.*\.test\.(js|ts)$).*/.test(
+        file
+      );
+  }
+
+  await copy(
+    templatesPath,
+    shouldAddTemp(targetComponentPath),
+    copyOptions
+  );
 };


### PR DESCRIPTION
You can skip test file with `--skip-test`.
For examples:
`npx react-creates component MyComponent --skip-test`

files:
```
📦MyComponent
 ┣ 📜MyComponent.js
 ┣ 📜index.js
 ┗ 📜style.css
```